### PR TITLE
fix: speed up PR Docker builds by skipping arm64 QEMU emulation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,8 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64,linux/arm64
+        # Only build multi-platform on push (PRs just verify the build)
+        platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
   build-and-push-api:
     runs-on: ubuntu-latest
@@ -104,7 +105,8 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64,linux/arm64
+        # Only build multi-platform on push (PRs just verify the build)
+        platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
   # Optional: Also publish to Docker Hub
   docker-hub:

--- a/src/Acorn.Api/Dockerfile
+++ b/src/Acorn.Api/Dockerfile
@@ -14,6 +14,7 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 # Copy project files and restore dependencies (better layer caching)
+COPY ["Directory.Build.props", "./"]
 COPY ["src/Acorn.Api/Acorn.Api.csproj", "src/Acorn.Api/"]
 COPY ["src/Acorn.Shared/Acorn.Shared.csproj", "src/Acorn.Shared/"]
 COPY ["src/Acorn.Database/Acorn.Database.csproj", "src/Acorn.Database/"]

--- a/src/Acorn/Dockerfile
+++ b/src/Acorn/Dockerfile
@@ -15,6 +15,7 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 # Copy project files and restore dependencies (better layer caching)
+COPY ["Directory.Build.props", "./"]
 COPY ["src/Acorn/Acorn.csproj", "src/Acorn/"]
 COPY ["src/Acorn.Shared/Acorn.Shared.csproj", "src/Acorn.Shared/"]
 COPY ["src/Acorn.Database/Acorn.Database.csproj", "src/Acorn.Database/"]


### PR DESCRIPTION
## Summary
- Only build `linux/amd64` on PRs since images aren't pushed anyway — avoids slow QEMU-emulated arm64 compilation on amd64 runners
- Multi-platform (`amd64` + `arm64`) builds still run on push to main/tags when images are actually published
- Copy `Directory.Build.props` into both Dockerfiles so `TreatWarningsAsErrors` applies consistently in container builds

Should roughly halve PR Docker build time (~4 min instead of ~8 min).