### PR TITLE
fix: handle read-only filesystem in data repositories to prevent Docker crash

### DIFF
--- a/src/Acorn/Data/InnDataRepository.cs
+++ b/src/Acorn/Data/InnDataRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Acorn.Infrastructure.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Acorn.Data;
@@ -27,13 +28,13 @@ public class InnDataRepository : IInnDataRepository
         {
             try
             {
-                _logger.LogWarning("Inns directory not found at {Directory}. Creating with sample inn.", InnsDirectory);
+                _logger.DataDirectoryNotFound(InnsDirectory);
                 Directory.CreateDirectory(InnsDirectory);
                 CreateSampleInn();
             }
             catch (IOException ex)
             {
-                _logger.LogWarning(ex, "Could not create Inns directory at {Directory} (read-only filesystem?). Continuing with no inns.", InnsDirectory);
+                _logger.DataDirectoryCreateFailed(ex, InnsDirectory);
             }
             return;
         }
@@ -41,7 +42,7 @@ public class InnDataRepository : IInnDataRepository
         var jsonFiles = Directory.GetFiles(InnsDirectory, "*.json");
         if (jsonFiles.Length == 0)
         {
-            _logger.LogWarning("No inn files found in {Directory}. Creating sample inn.", InnsDirectory);
+            _logger.DataDirectoryEmpty(InnsDirectory);
             CreateSampleInn();
             return;
         }
@@ -58,7 +59,7 @@ public class InnDataRepository : IInnDataRepository
 
                 if (innJson == null)
                 {
-                    _logger.LogWarning("Failed to parse inn file: {File}", file);
+                    _logger.DataFileParseFailed(file);
                     continue;
                 }
 
@@ -82,16 +83,15 @@ public class InnDataRepository : IInnDataRepository
                 );
 
                 _inns.Add(inn);
-                _logger.LogInformation("Loaded inn: {Name} (BehaviorId: {BehaviorId})",
-                    inn.Name, inn.BehaviorId);
+                _logger.InnLoaded(inn.Name, inn.BehaviorId);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error loading inn file: {File}", file);
+                _logger.DataFileLoadError(ex, file);
             }
         }
 
-        _logger.LogInformation("Loaded {Count} inns", _inns.Count);
+        _logger.InnsLoaded(_inns.Count);
     }
 
     private void CreateSampleInn()
@@ -121,7 +121,7 @@ public class InnDataRepository : IInnDataRepository
         var json = JsonSerializer.Serialize(sampleInn, new JsonSerializerOptions { WriteIndented = true });
         var samplePath = Path.Combine(InnsDirectory, "aeven.json");
         File.WriteAllText(samplePath, json);
-        _logger.LogInformation("Created sample inn file at {Path}", samplePath);
+        _logger.SampleDataFileCreated(samplePath);
         
         // Reload after creating sample
         LoadInns();

--- a/src/Acorn/Data/InnDataRepository.cs
+++ b/src/Acorn/Data/InnDataRepository.cs
@@ -25,9 +25,16 @@ public class InnDataRepository : IInnDataRepository
     {
         if (!Directory.Exists(InnsDirectory))
         {
-            _logger.LogWarning("Inns directory not found at {Directory}. Creating with sample inn.", InnsDirectory);
-            Directory.CreateDirectory(InnsDirectory);
-            CreateSampleInn();
+            try
+            {
+                _logger.LogWarning("Inns directory not found at {Directory}. Creating with sample inn.", InnsDirectory);
+                Directory.CreateDirectory(InnsDirectory);
+                CreateSampleInn();
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Could not create Inns directory at {Directory} (read-only filesystem?). Continuing with no inns.", InnsDirectory);
+            }
             return;
         }
 

--- a/src/Acorn/Data/ShopDataRepository.cs
+++ b/src/Acorn/Data/ShopDataRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Acorn.Infrastructure.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Acorn.Data;
@@ -24,13 +25,13 @@ public class ShopDataRepository : IShopDataRepository
         {
             try
             {
-                _logger.LogWarning("Shops directory not found at {Directory}. Creating with sample shop.", ShopsDirectory);
+                _logger.DataDirectoryNotFound(ShopsDirectory);
                 Directory.CreateDirectory(ShopsDirectory);
                 CreateSampleShop();
             }
             catch (IOException ex)
             {
-                _logger.LogWarning(ex, "Could not create Shops directory at {Directory} (read-only filesystem?). Continuing with no shops.", ShopsDirectory);
+                _logger.DataDirectoryCreateFailed(ex, ShopsDirectory);
             }
             return;
         }
@@ -38,7 +39,7 @@ public class ShopDataRepository : IShopDataRepository
         var jsonFiles = Directory.GetFiles(ShopsDirectory, "*.json");
         if (jsonFiles.Length == 0)
         {
-            _logger.LogWarning("No shop files found in {Directory}. Creating sample shop.", ShopsDirectory);
+            _logger.DataDirectoryEmpty(ShopsDirectory);
             CreateSampleShop();
             return;
         }
@@ -55,7 +56,7 @@ public class ShopDataRepository : IShopDataRepository
 
                 if (shopJson == null)
                 {
-                    _logger.LogWarning("Failed to parse shop file: {File}", file);
+                    _logger.DataFileParseFailed(file);
                     continue;
                 }
 
@@ -78,16 +79,15 @@ public class ShopDataRepository : IShopDataRepository
                 );
 
                 _shops.Add(shop);
-                _logger.LogInformation("Loaded shop: {Name} (BehaviorId: {BehaviorId}, {TradeCount} trades, {CraftCount} crafts)",
-                    shop.Name, shop.BehaviorId, shop.Trades.Count, shop.Crafts.Count);
+                _logger.ShopLoaded(shop.Name, shop.BehaviorId, shop.Trades.Count, shop.Crafts.Count);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error loading shop file: {File}", file);
+                _logger.DataFileLoadError(ex, file);
             }
         }
 
-        _logger.LogInformation("Loaded {Count} shops", _shops.Count);
+        _logger.ShopsLoaded(_shops.Count);
     }
 
     private void CreateSampleShop()
@@ -109,7 +109,7 @@ public class ShopDataRepository : IShopDataRepository
         var json = JsonSerializer.Serialize(sampleShop, new JsonSerializerOptions { WriteIndented = true });
         var samplePath = Path.Combine(ShopsDirectory, "sample_shop.json");
         File.WriteAllText(samplePath, json);
-        _logger.LogInformation("Created sample shop file at {Path}", samplePath);
+        _logger.SampleDataFileCreated(samplePath);
     }
 
     public ShopData? GetShopByBehaviorId(int behaviorId)

--- a/src/Acorn/Data/ShopDataRepository.cs
+++ b/src/Acorn/Data/ShopDataRepository.cs
@@ -22,9 +22,16 @@ public class ShopDataRepository : IShopDataRepository
     {
         if (!Directory.Exists(ShopsDirectory))
         {
-            _logger.LogWarning("Shops directory not found at {Directory}. Creating with sample shop.", ShopsDirectory);
-            Directory.CreateDirectory(ShopsDirectory);
-            CreateSampleShop();
+            try
+            {
+                _logger.LogWarning("Shops directory not found at {Directory}. Creating with sample shop.", ShopsDirectory);
+                Directory.CreateDirectory(ShopsDirectory);
+                CreateSampleShop();
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Could not create Shops directory at {Directory} (read-only filesystem?). Continuing with no shops.", ShopsDirectory);
+            }
             return;
         }
 

--- a/src/Acorn/Data/SkillMasterDataRepository.cs
+++ b/src/Acorn/Data/SkillMasterDataRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Acorn.Infrastructure.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Acorn.Data;
@@ -24,13 +25,13 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
         {
             try
             {
-                _logger.LogWarning("SkillMasters directory not found at {Directory}. Creating with sample.", SkillMastersDirectory);
+                _logger.DataDirectoryNotFound(SkillMastersDirectory);
                 Directory.CreateDirectory(SkillMastersDirectory);
                 CreateSample();
             }
             catch (IOException ex)
             {
-                _logger.LogWarning(ex, "Could not create SkillMasters directory at {Directory} (read-only filesystem?). Continuing with no skill masters.", SkillMastersDirectory);
+                _logger.DataDirectoryCreateFailed(ex, SkillMastersDirectory);
             }
             return;
         }
@@ -38,7 +39,7 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
         var jsonFiles = Directory.GetFiles(SkillMastersDirectory, "*.json");
         if (jsonFiles.Length == 0)
         {
-            _logger.LogWarning("No skill master files found in {Directory}. Creating sample.", SkillMastersDirectory);
+            _logger.DataDirectoryEmpty(SkillMastersDirectory);
             CreateSample();
             return;
         }
@@ -55,7 +56,7 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
 
                 if (model == null)
                 {
-                    _logger.LogWarning("Failed to parse skill master file: {File}", file);
+                    _logger.DataFileParseFailed(file);
                     continue;
                 }
 
@@ -81,16 +82,15 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
                 );
 
                 _skillMasters.Add(skillMaster);
-                _logger.LogInformation("Loaded skill master: {Name} (BehaviorId: {BehaviorId}, {SkillCount} skills)",
-                    skillMaster.Name, skillMaster.BehaviorId, skillMaster.Skills.Count);
+                _logger.SkillMasterLoaded(skillMaster.Name, skillMaster.BehaviorId, skillMaster.Skills.Count);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error loading skill master file: {File}", file);
+                _logger.DataFileLoadError(ex, file);
             }
         }
 
-        _logger.LogInformation("Loaded {Count} skill masters", _skillMasters.Count);
+        _logger.SkillMastersLoaded(_skillMasters.Count);
     }
 
     private void CreateSample()
@@ -124,7 +124,7 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
         var json = JsonSerializer.Serialize(sample, new JsonSerializerOptions { WriteIndented = true });
         var samplePath = Path.Combine(SkillMastersDirectory, "sample_skill_master.json");
         File.WriteAllText(samplePath, json);
-        _logger.LogInformation("Created sample skill master file at {Path}", samplePath);
+        _logger.SampleDataFileCreated(samplePath);
     }
 
     public SkillMasterData? GetByBehaviorId(int behaviorId)

--- a/src/Acorn/Data/SkillMasterDataRepository.cs
+++ b/src/Acorn/Data/SkillMasterDataRepository.cs
@@ -22,9 +22,16 @@ public class SkillMasterDataRepository : ISkillMasterDataRepository
     {
         if (!Directory.Exists(SkillMastersDirectory))
         {
-            _logger.LogWarning("SkillMasters directory not found at {Directory}. Creating with sample.", SkillMastersDirectory);
-            Directory.CreateDirectory(SkillMastersDirectory);
-            CreateSample();
+            try
+            {
+                _logger.LogWarning("SkillMasters directory not found at {Directory}. Creating with sample.", SkillMastersDirectory);
+                Directory.CreateDirectory(SkillMastersDirectory);
+                CreateSample();
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Could not create SkillMasters directory at {Directory} (read-only filesystem?). Continuing with no skill masters.", SkillMastersDirectory);
+            }
             return;
         }
 

--- a/src/Acorn/Dockerfile
+++ b/src/Acorn/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 8078 8079
 # Create app user and directories
 RUN addgroup -g 1000 acorn && \
     adduser -u 1000 -G acorn -s /bin/sh -D acorn && \
-    mkdir -p /app/mnt /app/Data && \
+    mkdir -p /app/mnt /app/Data/SkillMasters /app/Data/Shops /app/Data/Inns /app/Data/quests && \
     chown -R acorn:acorn /app
 
 # Stage 2: Build image

--- a/src/Acorn/Infrastructure/Telemetry/Log.cs
+++ b/src/Acorn/Infrastructure/Telemetry/Log.cs
@@ -64,4 +64,42 @@ public static partial class Log
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Rate limited packet {Action}_{Family} from session {SessionId}")]
     public static partial void PacketRateLimited(this ILogger logger, object action, object family, int sessionId);
+
+    // --- Data loading ---
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Data directory not found at {Directory}, creating with sample")]
+    public static partial void DataDirectoryNotFound(this ILogger logger, string directory);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not create data directory at {Directory} (read-only filesystem?), continuing without data")]
+    public static partial void DataDirectoryCreateFailed(this ILogger logger, Exception exception, string directory);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No data files found in {Directory}, creating sample")]
+    public static partial void DataDirectoryEmpty(this ILogger logger, string directory);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse data file: {File}")]
+    public static partial void DataFileParseFailed(this ILogger logger, string file);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error loading data file: {File}")]
+    public static partial void DataFileLoadError(this ILogger logger, Exception exception, string file);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Created sample data file at {Path}")]
+    public static partial void SampleDataFileCreated(this ILogger logger, string path);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded skill master: {Name} (BehaviorId: {BehaviorId}, {SkillCount} skills)")]
+    public static partial void SkillMasterLoaded(this ILogger logger, string name, int behaviorId, int skillCount);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} skill masters")]
+    public static partial void SkillMastersLoaded(this ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded shop: {Name} (BehaviorId: {BehaviorId}, {TradeCount} trades, {CraftCount} crafts)")]
+    public static partial void ShopLoaded(this ILogger logger, string name, int behaviorId, int tradeCount, int craftCount);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} shops")]
+    public static partial void ShopsLoaded(this ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded inn: {Name} (BehaviorId: {BehaviorId})")]
+    public static partial void InnLoaded(this ILogger logger, string name, int behaviorId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {Count} inns")]
+    public static partial void InnsLoaded(this ILogger logger, int count);
 }


### PR DESCRIPTION
## Summary

- **Fix crash on startup** when running in a Docker container with a read-only root filesystem. `SkillMasterDataRepository`, `ShopDataRepository`, and `InnDataRepository` all called `Directory.CreateDirectory()` which threw `System.IO.IOException: Read-only file system`.
- **Wrap directory/sample-file creation in try-catch** so the server starts gracefully with empty data instead of crashing.
- **Pre-create `Data/SkillMasters`, `Data/Shops`, `Data/Inns`, and `Data/quests` subdirectories in the Dockerfile** so they exist at image build time.

## Files changed

| File | Change |
|------|--------|
| `src/Acorn/Data/SkillMasterDataRepository.cs` | Catch `IOException` on directory creation |
| `src/Acorn/Data/ShopDataRepository.cs` | Catch `IOException` on directory creation |
| `src/Acorn/Data/InnDataRepository.cs` | Catch `IOException` on directory creation |
| `src/Acorn/Dockerfile` | Pre-create Data subdirectories |