### PR TITLE
fix: implement EmoteReport handler to broadcast emotes

### DIFF
--- a/src/Acorn/Net/PacketHandlers/Player/EmoteReportClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Player/EmoteReportClientPacketHandler.cs
@@ -1,13 +1,28 @@
 ﻿using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
+using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
 
 namespace Acorn.Net.PacketHandlers.Player;
 
+[RequiresCharacter]
 public class EmoteReportClientPacketHandler : IPacketHandler<EmoteReportClientPacket>
 {
-    public Task HandleAsync(PlayerState playerState, EmoteReportClientPacket packet)
+    public async Task HandleAsync(PlayerState playerState, EmoteReportClientPacket packet)
     {
-        throw new NotImplementedException();
+        if (playerState.CurrentMap is null)
+        {
+            return;
+        }
+
+        var broadcast = playerState.CurrentMap.Players.Values
+            .Where(player => player.SessionId != playerState.SessionId)
+            .Select(player => player.Send(new EmotePlayerServerPacket
+            {
+                PlayerId = playerState.SessionId,
+                Emote = packet.Emote
+            }));
+
+        await Task.WhenAll(broadcast);
     }
 
 }


### PR DESCRIPTION
## Summary
- `EmoteReportClientPacketHandler` threw `NotImplementedException` for every `Emote_Report` packet
- Now broadcasts `Emote_Player` to other nearby players on the map, mirroring `FacePlayerClientPacketHandler`
- Added `[RequiresCharacter]` so it's skipped safely if no character/map is loaded yet

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors

Closes #9