### PR TITLE
fix: implement BookRequest handler to return player info

### DIFF
--- a/src/Acorn/Net/PacketHandlers/Book/BookRequestClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Book/BookRequestClientPacketHandler.cs
@@ -1,13 +1,19 @@
+using Acorn.Data;
+using Acorn.Extensions;
 using Acorn.World;
 using Microsoft.Extensions.Logging;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
+using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
 using Acorn.Net.PacketHandlers;
 
 namespace Acorn.Net.PacketHandlers.Book;
 
 [RequiresCharacter]
-public class BookRequestClientPacketHandler(ILogger<BookRequestClientPacketHandler> logger)
+public class BookRequestClientPacketHandler(
+    IWorldQueries world,
+    IQuestDataRepository questDataRepository,
+    ILogger<BookRequestClientPacketHandler> logger)
     : IPacketHandler<BookRequestClientPacket>
 {
     public async Task HandleAsync(PlayerState player, BookRequestClientPacket packet)
@@ -15,8 +21,44 @@ public class BookRequestClientPacketHandler(ILogger<BookRequestClientPacketHandl
         logger.LogInformation("Player {Character} requesting book from player {PlayerId}",
             player.Character!.Name, packet.PlayerId);
 
-        // TODO: Implement map.RequestBook(player, playerId)
-        await Task.CompletedTask;
+        var targetPlayer = world.GetPlayer(packet.PlayerId);
+        if (targetPlayer?.Character is null)
+        {
+            return;
+        }
+
+        var character = targetPlayer.Character;
+
+        var questNames = character.Quests
+            .Where(q => q.DoneAt == null)
+            .Select(q => questDataRepository.GetQuest(q.QuestId)?.Name)
+            .Where(name => name != null)
+            .Cast<string>()
+            .ToList();
+
+        await player.Send(new BookReplyServerPacket
+        {
+            Details = new CharacterDetails
+            {
+                Name = character.Name,
+                Home = character.Home ?? "",
+                Admin = character.Admin,
+                Partner = character.Partner ?? "",
+                Title = character.Title ?? "",
+                Guild = "", // TODO: Implement guilds
+                GuildRank = "", // TODO: Implement guilds
+                PlayerId = packet.PlayerId,
+                ClassId = character.Class,
+                Gender = character.Gender
+            },
+            Icon = (int)character.Admin switch
+            {
+                0 => CharacterIcon.Player,
+                1 or 2 or 3 => CharacterIcon.Gm,
+                _ => CharacterIcon.Hgm
+            },
+            QuestNames = questNames
+        });
     }
 
 }


### PR DESCRIPTION
## Summary
`BookRequestClientPacketHandler` logged the request but never sent a reply, so the paperdoll "book" popup for other players never populated.

- Send `Book_Reply` with the target's name, home, partner, title, guild placeholder, class, gender
- Map admin level to `CharacterIcon` (Player/Gm/Hgm), same mapping used by `AsOnlinePlayer`
- Populate `QuestNames` from the target's in-progress quests via `IQuestDataRepository`

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [x] `dotnet test` — all 46 tests pass

Closes #14