### PR TITLE
feat: add global NPC gold drops

### DIFF
--- a/src/Acorn/Data/global_drops.txt
+++ b/src/Acorn/Data/global_drops.txt
@@ -1,0 +1,8 @@
+# Global NPC Drop Table Configuration
+# These drops are rolled for every NPC kill, in addition to that NPC's
+# specific entry in drops.txt (if any). Used for drops that should apply
+# broadly rather than being configured per-NPC, such as a baseline gold chance.
+# Format: item_id,min,max,percentage
+# Percentage is 0-100 (supports decimals like 0.5)
+
+1,1,5,15

--- a/src/Acorn/Database/Repository/DropFileTextLoader.cs
+++ b/src/Acorn/Database/Repository/DropFileTextLoader.cs
@@ -85,5 +85,60 @@ public class DropFileTextLoader
             _logger.LogError(ex, "Error loading drops from {FilePath}", filePath);
         }
     }
+
+    /// <summary>
+    ///     Loads drops that apply to every NPC (e.g. a universal gold chance) from a text
+    ///     configuration file.
+    ///     Format: item_id,min,max,chance
+    /// </summary>
+    public void LoadGlobalDrops(ILootService lootService, string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                _logger.LogWarning("Global drop file not found: {FilePath}", filePath);
+                return;
+            }
+
+            var lines = File.ReadAllLines(filePath);
+            var globalDrops = new List<LootDrop>();
+
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#") || line.StartsWith("//"))
+                    continue;
+
+                var parts = line.Split(',');
+                if (parts.Length != 4)
+                    continue;
+
+                if (!int.TryParse(parts[0].Trim(), out var itemId) ||
+                    !int.TryParse(parts[1].Trim(), out var min) ||
+                    !int.TryParse(parts[2].Trim(), out var max) ||
+                    !int.TryParse(parts[3].Trim(), out var chance))
+                    continue;
+
+                globalDrops.Add(new LootDrop
+                {
+                    ItemId = itemId,
+                    MinAmount = min,
+                    MaxAmount = max,
+                    RatePercent = chance
+                });
+            }
+
+            if (globalDrops.Count > 0)
+            {
+                lootService.RegisterGlobalDrops(globalDrops);
+            }
+
+            _logger.LogInformation("Loaded {Count} global drops from {FilePath}", globalDrops.Count, filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading global drops from {FilePath}", filePath);
+        }
+    }
 }
 

--- a/src/Acorn/Game/Services/LootService.cs
+++ b/src/Acorn/Game/Services/LootService.cs
@@ -18,8 +18,16 @@ public interface ILootService
     void RegisterNpcLootTable(NpcLootTable lootTable);
 
     /// <summary>
+    ///     Register drops that apply to every NPC kill, in addition to that NPC's
+    ///     specific loot table (e.g. a universal gold chance). Matches reoserv's
+    ///     GlobalDrops concept.
+    /// </summary>
+    void RegisterGlobalDrops(IEnumerable<LootDrop> drops);
+
+    /// <summary>
     ///     Calculate a drop for an NPC kill (returns null if no drop occurs)
-    ///     Uses probability-based random selection with weighted rates
+    ///     Uses probability-based random selection with weighted rates.
+    ///     Considers both the NPC's specific loot table and the global drop table.
     /// </summary>
     LootDrop? RollDrop(int npcId);
 
@@ -35,6 +43,7 @@ public interface ILootService
 public class LootService : ILootService
 {
     private readonly Dictionary<int, NpcLootTable> _npcLootTables = new();
+    private readonly List<LootDrop> _globalDrops = new();
     private readonly Random _random = new();
 
     public NpcLootTable? GetNpcLootTable(int npcId)
@@ -47,16 +56,22 @@ public class LootService : ILootService
         _npcLootTables[lootTable.NpcId] = lootTable;
     }
 
+    public void RegisterGlobalDrops(IEnumerable<LootDrop> drops)
+    {
+        _globalDrops.AddRange(drops);
+    }
+
     public LootDrop? RollDrop(int npcId)
     {
-        var lootTable = GetNpcLootTable(npcId);
-        if (lootTable == null || lootTable.Drops.Count == 0)
+        var npcDrops = GetNpcLootTable(npcId)?.Drops ?? [];
+        var combinedDrops = npcDrops.Concat(_globalDrops).ToList();
+        if (combinedDrops.Count == 0)
         {
             return null;
         }
 
         // Sort drops by rate for proper probability weighting
-        var sortedDrops = lootTable.Drops
+        var sortedDrops = combinedDrops
             .OrderBy(d => d.RatePercent)
             .ToList();
 

--- a/src/Acorn/Net/PacketHandlers/Player/AttackUseClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Player/AttackUseClientPacketHandler.cs
@@ -126,7 +126,8 @@ internal class AttackUseClientPacketHandler : IPacketHandler<AttackUseClientPack
                     await playerState.CacheCharacterStateAsync(_characterCache, _paperdollService);
                 }
 
-                // Roll for item drop
+                // Roll for a drop (item or gold — gold is item ID 1, rolled from the NPC's
+                // specific loot table plus the global drop table)
                 var dropItem = _lootService.RollDrop(target.Id);
                 var dropId = 0;
                 var dropAmount = 0;
@@ -207,8 +208,6 @@ internal class AttackUseClientPacketHandler : IPacketHandler<AttackUseClientPack
                         NpcKilledData = npcKilledData
                     }, playerState);
                 }
-
-                // TODO: Handle NPC drops (items, gold)
             }
         }
 

--- a/src/Acorn/World/DropTableHostedService.cs
+++ b/src/Acorn/World/DropTableHostedService.cs
@@ -31,6 +31,9 @@ internal class DropTableHostedService : IHostedService
         var dropFilePath = Path.Combine(AppContext.BaseDirectory, "Data", "drops.txt");
         _dropFileLoader.LoadDrops(_lootService, dropFilePath);
 
+        var globalDropFilePath = Path.Combine(AppContext.BaseDirectory, "Data", "global_drops.txt");
+        _dropFileLoader.LoadGlobalDrops(_lootService, globalDropFilePath);
+
         return Task.CompletedTask;
     }
 

--- a/tests/Acorn.Tests/Game/Services/LootServiceTests.cs
+++ b/tests/Acorn.Tests/Game/Services/LootServiceTests.cs
@@ -1,0 +1,77 @@
+using Acorn.Game.Models;
+using Acorn.Game.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Acorn.Tests.Game.Services;
+
+public class LootServiceTests
+{
+    private readonly LootService _sut;
+
+    public LootServiceTests()
+    {
+        _sut = new LootService();
+    }
+
+    [Fact]
+    public void RollDrop_WhenNpcHasNoLootTableAndNoGlobalDrops_ShouldReturnNull()
+    {
+        var result = _sut.RollDrop(npcId: 999);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void RollDrop_WhenNpcHasNoSpecificLootTable_ShouldStillRollGlobalDrops()
+    {
+        // A 100% global drop should always be returned, even for an NPC with no
+        // NPC-specific loot table registered (e.g. a universal gold drop).
+        _sut.RegisterGlobalDrops([new LootDrop(itemId: 1, minAmount: 1, maxAmount: 5, ratePercent: 100)]);
+
+        var result = _sut.RollDrop(npcId: 42);
+
+        result.Should().NotBeNull();
+        result!.ItemId.Should().Be(1);
+    }
+
+    [Fact]
+    public void RollDrop_ShouldConsiderBothNpcSpecificAndGlobalDrops()
+    {
+        _sut.RegisterNpcLootTable(new NpcLootTable
+        {
+            NpcId = 1,
+            Drops = [new LootDrop(itemId: 100, minAmount: 1, maxAmount: 1, ratePercent: 100)]
+        });
+        _sut.RegisterGlobalDrops([new LootDrop(itemId: 1, minAmount: 1, maxAmount: 5, ratePercent: 100)]);
+
+        // Both rates are 100%, so a roll should always return one of the two configured drops.
+        var result = _sut.RollDrop(npcId: 1);
+
+        result.Should().NotBeNull();
+        new[] { 1, 100 }.Should().Contain(result!.ItemId);
+    }
+
+    [Fact]
+    public void RollDrop_WhenRateIsZero_ShouldNeverDrop()
+    {
+        _sut.RegisterGlobalDrops([new LootDrop(itemId: 1, minAmount: 1, maxAmount: 5, ratePercent: 0)]);
+
+        for (var i = 0; i < 50; i++)
+        {
+            _sut.RollDrop(npcId: 1).Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void RollDropAmount_ShouldReturnValueWithinRange()
+    {
+        var drop = new LootDrop(itemId: 1, minAmount: 3, maxAmount: 7, ratePercent: 100);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var amount = _sut.RollDropAmount(drop);
+            amount.Should().BeInRange(3, 7);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
NPC gold drops weren't happening for the vast majority of NPCs. `AttackUseClientPacketHandler` already treats gold generically — it's just item ID 1 — so any NPC with a `1,min,max,chance` line in `drops.txt` could already drop gold via the existing item-drop path. The gap is that only ~15 of the NPCs in `drops.txt` have such a line; every other NPC had zero chance of ever dropping gold.

I checked how reoserv resolves this (`sorokya/reoserv`: `attack_npc_replies.rs` / `global_drops.rs`) — it merges a **global drop table** into every NPC's roll in addition to that NPC's specific table, typically used for a baseline gold chance that applies broadly. This PR adds the same concept:

- `ILootService.RegisterGlobalDrops` + `RollDrop` now combines the NPC-specific loot table with the global one before rolling (same rate-sorted, first-match-wins algorithm — unchanged)
- New `Data/global_drops.txt` (`item_id,min,max,percentage`), seeded with a modest universal gold chance, loaded by `DropTableHostedService` alongside the existing per-NPC `drops.txt`
- No changes needed in `AttackUseClientPacketHandler`'s drop/broadcast/kill-steal-protection code — it already handles any `RollDrop` result generically, gold included, so protection and the `Npc_Spec`/`Npc_Accept` payload work unchanged

Note: only one drop (item or gold) can result per kill — this matches confirmed reoserv/eoserv behavior (single `drop_id` slot on the wire), not a limitation introduced here.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [x] `dotnet test` — all 51 tests pass (5 new `LootServiceTests` covering the global-drop merge)

Closes #15