### PR TITLE
feat: implement spell casting

### DIFF
--- a/src/Acorn/Extensions/IocExtensions.cs
+++ b/src/Acorn/Extensions/IocExtensions.cs
@@ -15,6 +15,7 @@ using Acorn.World.Services.Quest;
 using Acorn.World.Services.Npc;
 using Acorn.World.Services.Party;
 using Acorn.World.Services.Player;
+using Acorn.World.Services.Spell;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -88,6 +89,7 @@ internal static class IocRegistrations
             .AddSingleton<IAdminService, AdminService>()
             .AddSingleton<IMarriageService, MarriageService>()
             .AddSingleton<IMapItemService, MapItemService>()
+            .AddSingleton<ISpellCastService, SpellCastService>()
             // Lazy<T> registration to break circular dependencies
             .AddTransient(typeof(Lazy<>), typeof(LazyServiceProvider<>));
     }

--- a/src/Acorn/FormulaService.cs
+++ b/src/Acorn/FormulaService.cs
@@ -75,8 +75,10 @@ public class FormulaService : IFormulaService
 
     /// <summary>
     ///     Calculate damage dealt to an NPC.
+    ///     Optional bonus min/max damage is added before rolling (e.g. from a spell's own damage range).
     /// </summary>
-    public int CalculateDamageToNpc(Character character, EnfRecord npcData, bool attackingBackOrSide = false)
+    public int CalculateDamageToNpc(Character character, EnfRecord npcData, bool attackingBackOrSide = false,
+        int bonusMinDamage = 0, int bonusMaxDamage = 0)
     {
         // Check if attack hits
         if (!DoesAttackHit(character.Accuracy, npcData.Evade))
@@ -85,7 +87,7 @@ public class FormulaService : IFormulaService
         }
 
         // Roll damage between min and max
-        var rawDamage = _random.Next(character.MinDamage, character.MaxDamage + 1);
+        var rawDamage = _random.Next(character.MinDamage + bonusMinDamage, character.MaxDamage + bonusMaxDamage + 1);
 
         // Critical hit if NPC is at full HP or attacking from back/side
         var critical = npcData.Hp == npcData.Hp || attackingBackOrSide;
@@ -115,8 +117,10 @@ public class FormulaService : IFormulaService
 
     /// <summary>
     ///     Calculate damage dealt to a player.
+    ///     Optional bonus min/max damage is added before rolling (e.g. from a spell's own damage range).
     /// </summary>
-    public int CalculateDamageToPlayer(Character attacker, Character target, bool attackingBackOrSide = false)
+    public int CalculateDamageToPlayer(Character attacker, Character target, bool attackingBackOrSide = false,
+        int bonusMinDamage = 0, int bonusMaxDamage = 0)
     {
         // Check if attack hits
         if (!DoesAttackHit(attacker.Accuracy, target.Evade))
@@ -125,7 +129,7 @@ public class FormulaService : IFormulaService
         }
 
         // Roll damage between min and max
-        var rawDamage = _random.Next(attacker.MinDamage, attacker.MaxDamage + 1);
+        var rawDamage = _random.Next(attacker.MinDamage + bonusMinDamage, attacker.MaxDamage + bonusMaxDamage + 1);
 
         // Critical hit if target is at full HP or attacking from back/side
         var critical = target.Hp == target.MaxHp || attackingBackOrSide;

--- a/src/Acorn/IFormulaService.cs
+++ b/src/Acorn/IFormulaService.cs
@@ -25,8 +25,10 @@ public interface IFormulaService
 
     /// <summary>
     ///     Calculate damage dealt to an NPC.
+    ///     Optional bonus min/max damage is added before rolling (e.g. from a spell's own damage range).
     /// </summary>
-    int CalculateDamageToNpc(Character character, EnfRecord npcData, bool attackingBackOrSide = false);
+    int CalculateDamageToNpc(Character character, EnfRecord npcData, bool attackingBackOrSide = false,
+        int bonusMinDamage = 0, int bonusMaxDamage = 0);
 
     /// <summary>
     ///     Calculate damage dealt by an NPC to a player.
@@ -35,8 +37,10 @@ public interface IFormulaService
 
     /// <summary>
     ///     Calculate damage dealt to a player.
+    ///     Optional bonus min/max damage is added before rolling (e.g. from a spell's own damage range).
     /// </summary>
-    int CalculateDamageToPlayer(Character attacker, Character target, bool attackingBackOrSide = false);
+    int CalculateDamageToPlayer(Character attacker, Character target, bool attackingBackOrSide = false,
+        int bonusMinDamage = 0, int bonusMaxDamage = 0);
 
     /// <summary>
     ///     Calculate max HP.

--- a/src/Acorn/Net/PacketHandlers/Spell/SpellRequestClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Spell/SpellRequestClientPacketHandler.cs
@@ -1,3 +1,4 @@
+using Acorn.World.Services.Spell;
 using Microsoft.Extensions.Logging;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
@@ -7,6 +8,7 @@ namespace Acorn.Net.PacketHandlers.Spell;
 
 [RequiresCharacter]
 public class SpellRequestClientPacketHandler(
+    ISpellCastService spellCastService,
     ILogger<SpellRequestClientPacketHandler> logger)
     : IPacketHandler<SpellRequestClientPacket>
 {
@@ -26,8 +28,7 @@ public class SpellRequestClientPacketHandler(
         player.Timestamp = packet.Timestamp;
         player.SpellId = packet.SpellId;
 
-        // TODO: Implement map.StartSpellChant(player.Id, spellId)
-        await Task.CompletedTask;
+        await spellCastService.StartChantAsync(player, packet.SpellId);
     }
 
 }

--- a/src/Acorn/Net/PacketHandlers/Spell/SpellTargetGroupClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Spell/SpellTargetGroupClientPacketHandler.cs
@@ -1,3 +1,4 @@
+using Acorn.World.Services.Spell;
 using Microsoft.Extensions.Logging;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
@@ -7,6 +8,7 @@ namespace Acorn.Net.PacketHandlers.Spell;
 
 [RequiresCharacter]
 public class SpellTargetGroupClientPacketHandler(
+    ISpellCastService spellCastService,
     ILogger<SpellTargetGroupClientPacketHandler> logger)
     : IPacketHandler<SpellTargetGroupClientPacket>
 {
@@ -21,7 +23,7 @@ public class SpellTargetGroupClientPacketHandler(
         }
 
         // Validate timestamp
-        if (!CheckTimestamp(player, packet.Timestamp))
+        if (!spellCastService.ValidateCastTime(player, packet.SpellId, packet.Timestamp))
         {
             logger.LogWarning("Player {Character} spell timestamp validation failed for spell {SpellId}",
                 player.Character!.Name, packet.SpellId);
@@ -35,15 +37,7 @@ public class SpellTargetGroupClientPacketHandler(
         player.Timestamp = packet.Timestamp;
         player.SpellId = null;
 
-        // TODO: Implement map.CastSpell(player, spellId, SpellTarget.Group)
-        await Task.CompletedTask;
+        await spellCastService.CastAsync(player, packet.SpellId, SpellCastTarget.Group());
     }
 
-
-    private bool CheckTimestamp(PlayerState player, int timestamp)
-    {
-        // TODO: Load spell data from database and validate cast time
-        // For now, just do basic validation that timestamp has progressed
-        return timestamp >= player.Timestamp;
-    }
 }

--- a/src/Acorn/Net/PacketHandlers/Spell/SpellTargetOtherClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Spell/SpellTargetOtherClientPacketHandler.cs
@@ -1,3 +1,4 @@
+using Acorn.World.Services.Spell;
 using Microsoft.Extensions.Logging;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
@@ -7,6 +8,7 @@ namespace Acorn.Net.PacketHandlers.Spell;
 
 [RequiresCharacter]
 public class SpellTargetOtherClientPacketHandler(
+    ISpellCastService spellCastService,
     ILogger<SpellTargetOtherClientPacketHandler> logger)
     : IPacketHandler<SpellTargetOtherClientPacket>
 {
@@ -21,7 +23,7 @@ public class SpellTargetOtherClientPacketHandler(
         }
 
         // Validate timestamp
-        if (!CheckTimestamp(player, packet.SpellId, packet.Timestamp))
+        if (!spellCastService.ValidateCastTime(player, packet.SpellId, packet.Timestamp))
         {
             logger.LogWarning("Player {Character} spell timestamp validation failed for spell {SpellId}",
                 player.Character!.Name, packet.SpellId);
@@ -35,16 +37,19 @@ public class SpellTargetOtherClientPacketHandler(
         player.Timestamp = packet.Timestamp;
         player.SpellId = null;
 
-        // TODO: Implement map.CastSpell(player, spellId, SpellTarget.OtherPlayer/Npc(victimId))
-        // Handle packet.TargetType (Player or Npc)
-        await Task.CompletedTask;
+        var target = packet.TargetType switch
+        {
+            SpellTargetType.Player => SpellCastTarget.Player(packet.VictimId),
+            SpellTargetType.Npc => SpellCastTarget.Npc(packet.VictimId),
+            _ => (SpellCastTarget?)null
+        };
+
+        if (target is null)
+        {
+            return;
+        }
+
+        await spellCastService.CastAsync(player, packet.SpellId, target.Value);
     }
 
-
-    private bool CheckTimestamp(PlayerState player, int spellId, int timestamp)
-    {
-        // TODO: Load spell data from database and validate cast time
-        // For now, just do basic validation that timestamp has progressed
-        return timestamp >= player.Timestamp;
-    }
 }

--- a/src/Acorn/Net/PacketHandlers/Spell/SpellTargetSelfClientPacketHandler.cs
+++ b/src/Acorn/Net/PacketHandlers/Spell/SpellTargetSelfClientPacketHandler.cs
@@ -1,3 +1,4 @@
+using Acorn.World.Services.Spell;
 using Microsoft.Extensions.Logging;
 using Moffat.EndlessOnline.SDK.Protocol.Net;
 using Moffat.EndlessOnline.SDK.Protocol.Net.Client;
@@ -7,6 +8,7 @@ namespace Acorn.Net.PacketHandlers.Spell;
 
 [RequiresCharacter]
 public class SpellTargetSelfClientPacketHandler(
+    ISpellCastService spellCastService,
     ILogger<SpellTargetSelfClientPacketHandler> logger)
     : IPacketHandler<SpellTargetSelfClientPacket>
 {
@@ -21,7 +23,7 @@ public class SpellTargetSelfClientPacketHandler(
         }
 
         // Validate timestamp
-        if (!CheckTimestamp(player, packet.SpellId, packet.Timestamp))
+        if (!spellCastService.ValidateCastTime(player, packet.SpellId, packet.Timestamp))
         {
             logger.LogWarning("Player {Character} spell timestamp validation failed for spell {SpellId}",
                 player.Character!.Name, packet.SpellId);
@@ -35,15 +37,7 @@ public class SpellTargetSelfClientPacketHandler(
         player.Timestamp = packet.Timestamp;
         player.SpellId = null;
 
-        // TODO: Implement map.CastSpell(player, spellId, SpellTarget.Player)
-        await Task.CompletedTask;
+        await spellCastService.CastAsync(player, packet.SpellId, SpellCastTarget.Self());
     }
 
-
-    private bool CheckTimestamp(PlayerState player, int spellId, int timestamp)
-    {
-        // TODO: Load spell data from database and validate cast time
-        // For now, just do basic validation that timestamp has progressed
-        return timestamp >= player.Timestamp;
-    }
 }

--- a/src/Acorn/World/Services/Spell/ISpellCastService.cs
+++ b/src/Acorn/World/Services/Spell/ISpellCastService.cs
@@ -1,0 +1,28 @@
+using Acorn.Net;
+
+namespace Acorn.World.Services.Spell;
+
+/// <summary>
+///     Handles spell chant timing, cast-time validation, and applying spell effects.
+///     Mirrors the AttackUse melee flow but for ESF-backed spells.
+/// </summary>
+public interface ISpellCastService
+{
+    /// <summary>
+    ///     Start a spell chant: validates the caster knows the spell and broadcasts
+    ///     Spell_Request to nearby players.
+    /// </summary>
+    Task StartChantAsync(PlayerState player, int spellId);
+
+    /// <summary>
+    ///     Validate that the elapsed time between the chant start and the target packet
+    ///     is consistent with the spell's cast time (reject casts that are too fast, and
+    ///     stale casts that are too slow).
+    /// </summary>
+    bool ValidateCastTime(PlayerState player, int spellId, int timestamp);
+
+    /// <summary>
+    ///     Apply a spell's effect (heal or attack) against the given target.
+    /// </summary>
+    Task CastAsync(PlayerState player, int spellId, SpellCastTarget target);
+}

--- a/src/Acorn/World/Services/Spell/SpellCastService.cs
+++ b/src/Acorn/World/Services/Spell/SpellCastService.cs
@@ -1,0 +1,553 @@
+using Acorn.Database.Repository;
+using Acorn.Extensions;
+using Acorn.Game.Services;
+using Acorn.Net;
+using Acorn.Options;
+using Acorn.Shared.Caching;
+using Acorn.World.Map;
+using NpcState = Acorn.World.Npc.NpcState;
+using Acorn.World.Services.Party;
+using Acorn.World.Services.Player;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moffat.EndlessOnline.SDK.Protocol;
+using Moffat.EndlessOnline.SDK.Protocol.Net;
+using Moffat.EndlessOnline.SDK.Protocol.Net.Server;
+using Moffat.EndlessOnline.SDK.Protocol.Pub;
+using NpcType = Moffat.EndlessOnline.SDK.Protocol.Pub.NpcType;
+
+namespace Acorn.World.Services.Spell;
+
+public class SpellCastService(
+    IDataFileRepository dataFiles,
+    IFormulaService formulaService,
+    IPartyService partyService,
+    ILootService lootService,
+    IPlayerController playerController,
+    ICharacterCacheService characterCache,
+    IPaperdollService paperdollService,
+    IOptions<ServerOptions> serverOptions,
+    ILogger<SpellCastService> logger)
+    : ISpellCastService
+{
+    // MAX_TIMESTAMP and the cast-time window formula match reoserv's
+    // player::check_timestamp / utils::timestamp_diff exactly.
+    private const int MaxTimestamp = 8640000;
+    private readonly int _dropProtectionTicks = serverOptions.Value.DropProtectionTicks;
+
+    public async Task StartChantAsync(PlayerState player, int spellId)
+    {
+        if (player.Character is null || player.CurrentMap is null)
+        {
+            return;
+        }
+
+        if (!player.Character.Spells.Items.Any(s => s.Id == spellId))
+        {
+            return;
+        }
+
+        if (player.Character.Hidden)
+        {
+            return;
+        }
+
+        await player.CurrentMap.BroadcastPacket(new SpellRequestServerPacket
+        {
+            PlayerId = player.SessionId,
+            SpellId = spellId
+        }, player);
+    }
+
+    public bool ValidateCastTime(PlayerState player, int spellId, int timestamp)
+    {
+        var spell = dataFiles.Esf.GetSkill(spellId);
+        if (spell is null)
+        {
+            return false;
+        }
+
+        var diff = TimestampDiff(timestamp, player.Timestamp);
+        return diff >= (spell.CastTime - 1) * 47 + 35 && diff < Math.Max(spell.CastTime, 1) * 50;
+    }
+
+    public async Task CastAsync(PlayerState player, int spellId, SpellCastTarget target)
+    {
+        if (player.Character is null || player.CurrentMap is null)
+        {
+            return;
+        }
+
+        if (!player.Character.Spells.Items.Any(s => s.Id == spellId))
+        {
+            return;
+        }
+
+        var spell = dataFiles.Esf.GetSkill(spellId);
+        if (spell is null)
+        {
+            return;
+        }
+
+        switch (spell.Type)
+        {
+            case SkillType.Heal:
+                await CastHealSpell(player, spellId, spell, target);
+                break;
+            case SkillType.Attack:
+                await CastDamageSpell(player, spellId, spell, target);
+                break;
+        }
+    }
+
+    private async Task CastHealSpell(PlayerState player, int spellId, EsfRecord spell, SpellCastTarget target)
+    {
+        if (spell.TargetRestrict != SkillTargetRestrict.Friendly)
+        {
+            return;
+        }
+
+        switch (target.Type)
+        {
+            case SpellCastTargetType.Self:
+                await CastHealSelf(player, spellId, spell);
+                break;
+            case SpellCastTargetType.Group:
+                await CastHealGroup(player, spellId, spell);
+                break;
+            case SpellCastTargetType.OtherPlayer:
+                await CastHealOtherPlayer(player, target.VictimId, spellId, spell);
+                break;
+        }
+    }
+
+    private async Task CastHealSelf(PlayerState player, int spellId, EsfRecord spell)
+    {
+        if (spell.TargetType != SkillTargetType.Self)
+        {
+            return;
+        }
+
+        var character = player.Character!;
+        if (character.Tp < spell.TpCost)
+        {
+            return;
+        }
+
+        character.Tp -= spell.TpCost;
+        var originalHp = character.Hp;
+        character.Hp = Math.Min(character.Hp + spell.HpHeal, character.MaxHp);
+        var hpPercentage = HpPercentage(character.Hp, character.MaxHp);
+
+        await player.Send(new SpellTargetSelfServerPacket
+        {
+            PlayerId = player.SessionId,
+            SpellId = spellId,
+            SpellHealHp = spell.HpHeal,
+            HpPercentage = hpPercentage,
+            Hp = character.Hp,
+            Tp = character.Tp
+        });
+
+        await player.CurrentMap!.BroadcastPacket(new SpellTargetSelfServerPacket
+        {
+            PlayerId = player.SessionId,
+            SpellId = spellId,
+            SpellHealHp = spell.HpHeal,
+            HpPercentage = hpPercentage,
+            Hp = null,
+            Tp = null
+        }, player);
+
+        if (character.Hp != originalHp)
+        {
+            await partyService.BroadcastHpUpdate(player);
+        }
+    }
+
+    private async Task CastHealOtherPlayer(PlayerState player, int targetSessionId, int spellId, EsfRecord spell)
+    {
+        if (spell.TargetType != SkillTargetType.Normal)
+        {
+            return;
+        }
+
+        if (!player.CurrentMap!.Players.TryGetValue(targetSessionId, out var targetPlayer) ||
+            targetPlayer.Character is null)
+        {
+            return;
+        }
+
+        var character = player.Character!;
+        if (character.Tp < spell.TpCost)
+        {
+            return;
+        }
+
+        character.Tp -= spell.TpCost;
+
+        var targetCharacter = targetPlayer.Character;
+        var originalHp = targetCharacter.Hp;
+        targetCharacter.Hp = Math.Min(targetCharacter.Hp + spell.HpHeal, targetCharacter.MaxHp);
+        var hpPercentage = HpPercentage(targetCharacter.Hp, targetCharacter.MaxHp);
+
+        await player.CurrentMap.BroadcastPacket(new SpellTargetOtherServerPacket
+        {
+            VictimId = targetSessionId,
+            CasterId = player.SessionId,
+            CasterDirection = character.Direction,
+            SpellId = spellId,
+            SpellHealHp = spell.HpHeal,
+            HpPercentage = hpPercentage,
+            Hp = null
+        }, targetPlayer);
+
+        await targetPlayer.Send(new SpellTargetOtherServerPacket
+        {
+            VictimId = targetSessionId,
+            CasterId = player.SessionId,
+            CasterDirection = character.Direction,
+            SpellId = spellId,
+            SpellHealHp = spell.HpHeal,
+            HpPercentage = hpPercentage,
+            Hp = targetCharacter.Hp
+        });
+
+        await player.Send(new RecoverPlayerServerPacket { Hp = character.Hp, Tp = character.Tp });
+
+        if (targetCharacter.Hp != originalHp)
+        {
+            await partyService.BroadcastHpUpdate(targetPlayer);
+        }
+    }
+
+    private async Task CastHealGroup(PlayerState player, int spellId, EsfRecord spell)
+    {
+        var character = player.Character!;
+        if (character.Tp < spell.TpCost)
+        {
+            return;
+        }
+
+        var party = partyService.GetPlayerParty(player.SessionId);
+        if (party is null)
+        {
+            return;
+        }
+
+        character.Tp -= spell.TpCost;
+
+        var healedPlayers = new List<GroupHealTargetPlayer>();
+        foreach (var memberId in party.Members)
+        {
+            if (!player.CurrentMap!.Players.TryGetValue(memberId, out var member) || member.Character is null)
+            {
+                continue;
+            }
+
+            var originalHp = member.Character.Hp;
+            member.Character.Hp = Math.Min(member.Character.Hp + spell.HpHeal, member.Character.MaxHp);
+            var hpPercentage = HpPercentage(member.Character.Hp, member.Character.MaxHp);
+
+            if (member.Character.Hp != originalHp)
+            {
+                await partyService.BroadcastHpUpdate(member);
+            }
+
+            healedPlayers.Add(new GroupHealTargetPlayer
+            {
+                PlayerId = memberId,
+                HpPercentage = hpPercentage,
+                Hp = member.Character.Hp
+            });
+        }
+
+        if (healedPlayers.Count == 0)
+        {
+            return;
+        }
+
+        await player.CurrentMap!.BroadcastPacket(new SpellTargetGroupServerPacket
+        {
+            SpellId = spellId,
+            CasterId = player.SessionId,
+            CasterTp = character.Tp,
+            SpellHealHp = spell.HpHeal,
+            Players = healedPlayers
+        });
+    }
+
+    private async Task CastDamageSpell(PlayerState player, int spellId, EsfRecord spell, SpellCastTarget target)
+    {
+        if (spell.TargetRestrict == SkillTargetRestrict.Friendly || spell.TargetType != SkillTargetType.Normal)
+        {
+            return;
+        }
+
+        switch (target.Type)
+        {
+            case SpellCastTargetType.Npc:
+                await CastDamageNpc(player, target.VictimId, spellId, spell);
+                break;
+            case SpellCastTargetType.OtherPlayer:
+                await CastDamagePlayer(player, target.VictimId, spellId, spell);
+                break;
+        }
+    }
+
+    private async Task CastDamageNpc(PlayerState player, int npcIndex, int spellId, EsfRecord spell)
+    {
+        var map = player.CurrentMap!;
+        var character = player.Character!;
+
+        if (!map.Npcs.TryGetValue(npcIndex, out var npc) || npc.IsDead)
+        {
+            return;
+        }
+
+        if (npc.Data.Type is not (NpcType.Aggressive or NpcType.Passive))
+        {
+            return;
+        }
+
+        if (character.Tp < spell.TpCost)
+        {
+            return;
+        }
+
+        character.Tp -= spell.TpCost;
+
+        var damage = formulaService.CalculateDamageToNpc(character, npc.Data,
+            bonusMinDamage: spell.MinDamage, bonusMaxDamage: spell.MaxDamage);
+        npc.Hp = Math.Max(0, npc.Hp - damage);
+
+        if (damage > 0)
+        {
+            npc.AddOpponent(player.SessionId, damage);
+        }
+
+        await player.Send(new RecoverPlayerServerPacket { Hp = character.Hp, Tp = character.Tp });
+
+        var hpPercentage = npc.Data.Hp > 0 ? (int)Math.Max((double)npc.Hp / npc.Data.Hp * 100, 0) : 0;
+
+        if (npc.Hp > 0)
+        {
+            await player.Send(new CastReplyServerPacket
+            {
+                SpellId = spellId,
+                CasterId = player.SessionId,
+                CasterDirection = character.Direction,
+                NpcIndex = npcIndex,
+                Damage = damage,
+                HpPercentage = hpPercentage,
+                CasterTp = character.Tp,
+                KillStealProtection = NpcKillStealProtectionState.Unprotected
+            });
+
+            await map.BroadcastPacket(new CastReplyServerPacket
+            {
+                SpellId = spellId,
+                CasterId = player.SessionId,
+                CasterDirection = character.Direction,
+                NpcIndex = npcIndex,
+                Damage = damage,
+                HpPercentage = hpPercentage
+            }, player);
+        }
+        else
+        {
+            await HandleNpcKilledBySpell(player, npc, npcIndex, spellId, damage);
+        }
+    }
+
+    private async Task HandleNpcKilledBySpell(PlayerState player, NpcState npc, int npcIndex, int spellId,
+        int damage)
+    {
+        var character = player.Character!;
+        var map = player.CurrentMap!;
+
+        npc.IsDead = true;
+        npc.DeathTime = DateTime.UtcNow;
+        npc.Opponents.Clear();
+
+        var experienceGained = npc.Data.Experience;
+        character.GainExperience(experienceGained);
+
+        logger.LogInformation("Player {Character} killed NPC {NpcName} with spell {SpellId}",
+            character.Name, npc.Data.Name, spellId);
+
+        var levelsGained = 0;
+        while (formulaService.CanLevelUp(character))
+        {
+            formulaService.LevelUp(character, dataFiles.Ecf);
+            levelsGained++;
+        }
+
+        if (levelsGained > 0)
+        {
+            await player.CacheCharacterStateAsync(characterCache, paperdollService);
+        }
+
+        var dropItem = lootService.RollDrop(npc.Id);
+        var dropId = 0;
+        var dropAmount = 0;
+        var dropIndex = 0;
+
+        if (dropItem != null)
+        {
+            dropAmount = lootService.RollDropAmount(dropItem);
+            dropId = dropItem.ItemId;
+
+            var itemIndex = map.GetNextItemIndex();
+            map.Items.TryAdd(itemIndex, new MapItem
+            {
+                Id = dropId,
+                Amount = dropAmount,
+                Coords = new Coords { X = npc.X, Y = npc.Y },
+                OwnerId = player.SessionId,
+                ProtectedTicks = _dropProtectionTicks
+            });
+            dropIndex = itemIndex;
+        }
+
+        var npcKilledData = new NpcKilledData
+        {
+            KillerId = player.SessionId,
+            KillerDirection = character.Direction,
+            NpcIndex = npcIndex,
+            DropIndex = dropIndex,
+            DropId = dropId,
+            DropAmount = dropAmount,
+            DropCoords = new Coords { X = npc.X, Y = npc.Y },
+            Damage = damage
+        };
+
+        if (levelsGained > 0)
+        {
+            await player.Send(new CastAcceptServerPacket
+            {
+                SpellId = spellId,
+                NpcKilledData = npcKilledData,
+                CasterTp = character.Tp,
+                Experience = character.Exp,
+                LevelUp = new LevelUpStats
+                {
+                    Level = character.Level,
+                    StatPoints = character.StatPoints,
+                    SkillPoints = character.SkillPoints,
+                    MaxHp = character.MaxHp,
+                    MaxTp = character.MaxTp,
+                    MaxSp = character.MaxSp
+                }
+            });
+
+            await map.BroadcastPacket(new CastSpecServerPacket
+            {
+                SpellId = spellId,
+                NpcKilledData = npcKilledData
+            }, player);
+        }
+        else
+        {
+            await player.Send(new CastSpecServerPacket
+            {
+                SpellId = spellId,
+                NpcKilledData = npcKilledData,
+                CasterTp = character.Tp,
+                Experience = character.Exp
+            });
+
+            await map.BroadcastPacket(new CastSpecServerPacket
+            {
+                SpellId = spellId,
+                NpcKilledData = npcKilledData
+            }, player);
+        }
+    }
+
+    private async Task CastDamagePlayer(PlayerState player, int targetSessionId, int spellId, EsfRecord spell)
+    {
+        var map = player.CurrentMap!;
+        var character = player.Character!;
+
+        if (map.Data.Type != Moffat.EndlessOnline.SDK.Protocol.Map.MapType.Pk)
+        {
+            return;
+        }
+
+        if (!map.Players.TryGetValue(targetSessionId, out var targetPlayer) || targetPlayer.Character is null)
+        {
+            return;
+        }
+
+        if (targetPlayer.Character.Hidden)
+        {
+            return;
+        }
+
+        var party = partyService.GetPlayerParty(player.SessionId);
+        if (party is not null && party.Members.Contains(targetSessionId))
+        {
+            return;
+        }
+
+        if (character.Tp < spell.TpCost)
+        {
+            return;
+        }
+
+        var damage = formulaService.CalculateDamageToPlayer(character, targetPlayer.Character,
+            bonusMinDamage: spell.MinDamage, bonusMaxDamage: spell.MaxDamage);
+        targetPlayer.Character.Hp = Math.Max(0, targetPlayer.Character.Hp - damage);
+        character.Tp -= spell.TpCost;
+
+        await player.Send(new RecoverPlayerServerPacket { Hp = character.Hp, Tp = character.Tp });
+
+        var dead = targetPlayer.Character.Hp == 0;
+        var hpPercentage = HpPercentage(targetPlayer.Character.Hp, targetPlayer.Character.MaxHp);
+
+        await map.BroadcastPacket(new AvatarAdminServerPacket
+        {
+            CasterId = player.SessionId,
+            VictimId = targetSessionId,
+            CasterDirection = character.Direction,
+            Damage = damage,
+            HpPercentage = hpPercentage,
+            VictimDied = dead,
+            SpellId = spellId
+        });
+
+        if (dead)
+        {
+            await playerController.DieAsync(targetPlayer);
+        }
+
+        await targetPlayer.Send(new RecoverPlayerServerPacket
+        {
+            Hp = targetPlayer.Character.Hp,
+            Tp = targetPlayer.Character.Tp
+        });
+
+        await partyService.BroadcastHpUpdate(targetPlayer);
+    }
+
+    private static int HpPercentage(int hp, int maxHp)
+    {
+        return maxHp > 0 ? (int)Math.Round(hp * 100.0 / maxHp) : 0;
+    }
+
+    private static int TimestampDiff(int a, int b)
+    {
+        if (a == -1)
+        {
+            return b;
+        }
+
+        if (b == -1)
+        {
+            return a;
+        }
+
+        return b > a ? a - b + MaxTimestamp : a - b;
+    }
+}

--- a/src/Acorn/World/Services/Spell/SpellCastTarget.cs
+++ b/src/Acorn/World/Services/Spell/SpellCastTarget.cs
@@ -1,0 +1,36 @@
+namespace Acorn.World.Services.Spell;
+
+public enum SpellCastTargetType
+{
+    Self,
+    Group,
+    OtherPlayer,
+    Npc
+}
+
+/// <summary>
+///     Who a Spell_Target* packet is aimed at. For OtherPlayer, VictimId is a session ID;
+///     for Npc, VictimId is the NPC's map index.
+/// </summary>
+public readonly record struct SpellCastTarget(SpellCastTargetType Type, int VictimId = 0)
+{
+    public static SpellCastTarget Self()
+    {
+        return new SpellCastTarget(SpellCastTargetType.Self);
+    }
+
+    public static SpellCastTarget Group()
+    {
+        return new SpellCastTarget(SpellCastTargetType.Group);
+    }
+
+    public static SpellCastTarget Player(int sessionId)
+    {
+        return new SpellCastTarget(SpellCastTargetType.OtherPlayer, sessionId);
+    }
+
+    public static SpellCastTarget Npc(int npcIndex)
+    {
+        return new SpellCastTarget(SpellCastTargetType.Npc, npcIndex);
+    }
+}


### PR DESCRIPTION
## Summary
All four spell handlers (`Request`, `TargetSelf`, `TargetOther`, `TargetGroup`) validated state but never applied any effect or loaded ESF spell data — no magic worked at all.

I ported the reference implementation from reoserv (`sorokya/reoserv`: `player/handlers/spell.rs`, `map/character/{start_spell_chant,cast_spell}.rs`) into a new `ISpellCastService`:

- `Spell_Request` broadcasts `Spell_Request` to nearby players and starts the chant timer (validates the caster knows the spell)
- Cast-time validation uses reoserv's exact timing window formula: `diff >= (cast_time - 1) * 47 + 35 && diff < max(cast_time, 1) * 50`
- Heal spells (self / other player / group) restore HP within TP cost, broadcasting `Spell_TargetSelf` / `Spell_TargetOther` / `Spell_TargetGroup` and updating party HP bars
- Attack spells deal damage using a new bonus-damage overload on `IFormulaService.CalculateDamageToNpc`/`CalculateDamageToPlayer` (the spell's own min/max damage stacks with the caster's weapon damage, matching reoserv) and reuse the NPC death/XP/level-up/loot flow already used by melee attacks, broadcasting `Cast_Reply`/`Cast_Accept`/`Cast_Spec`
- Attack spells against players are restricted to PK maps and exempt party members from damage, for consistency with the melee PvP added in #13 (reoserv itself doesn't gate spell PvP by map type, but Acorn's melee path does now, so this closes what would otherwise be a bypass)
- Spell targeting an NPC resolves via the map's NPC index (dictionary key), not list position, matching the convention used by `NpcInteractionHelper` elsewhere

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [x] `dotnet test` — all 46 tests pass, including the integration suite that boots the full server (validates the new service's DI wiring)

Note: this branch was cut before #13 (PvP) merged, so `IFormulaService.CalculateDamageToPlayer`'s new optional bonus-damage parameters were deliberately placed *after* `attackingBackOrSide` to avoid silently reinterpreting #13's positional argument once both merge.

Closes #12